### PR TITLE
meson_plugin: catch proper json decode error

### DIFF
--- a/plugins/meson/meson_plugin/__init__.py
+++ b/plugins/meson/meson_plugin/__init__.py
@@ -113,7 +113,7 @@ class MesonBuildSystem(Ide.Object, Ide.BuildSystem, Gio.AsyncInitable):
             try:
                 with open(commands_file) as f:
                     commands = json.loads(f.read(), encoding='utf-8')
-            except (json.JSONDecodeError, FileNotFoundError, UnicodeDecodeError) as e:
+            except (ValueError, FileNotFoundError, UnicodeDecodeError) as e:
                 task.return_error(GLib.Error('Failed to decode meson json: {}'.format(e)))
                 return
 


### PR DESCRIPTION
I am trying gnome-build from flatpak, seems to work, but I keep getting the following error:

```
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "/app/lib/gnome-builder/plugins/meson_plugin/__init__.py", line 177, in build_flags_thread
    except (json.JSONDecodeError, FileNotFoundError, UnicodeDecodeError) as e:
AttributeError: 'module' object has no attribute 'JSONDecodeError'
```

JSONDecodeError no longer exists and it should be replaced by ValueError