### PR TITLE
workbench: Show tooltip when build or run actions are disabled

### DIFF
--- a/src/libide/runner/ide-run-button.c
+++ b/src/libide/runner/ide-run-button.c
@@ -111,7 +111,7 @@ ide_run_button_context_set (GtkWidget  *widget,
     ide_run_button_load (self, context);
 }
 
-static void
+static gboolean
 ide_run_button_query_tooltip (IdeRunButton *self,
                               gint          x,
                               gint          y,
@@ -146,9 +146,12 @@ ide_run_button_query_tooltip (IdeRunButton *self,
                         "visible", TRUE,
                         NULL);
           gtk_tooltip_set_custom (tooltip, GTK_WIDGET (self->run_shortcut));
-          break;
+
+          return TRUE;
         }
     }
+
+  return FALSE;
 }
 
 static void

--- a/src/libide/runner/ide-run-button.ui
+++ b/src/libide/runner/ide-run-button.ui
@@ -2,6 +2,10 @@
 <interface>
   <object class="GtkShortcutsShortcut" id="run_shortcut">
   </object>
+  <object class="GtkLabel" id="run_tooltip_message">
+    <property name="label" translatable="yes">The project cannot be run while the build pipeline is being set up</property>
+    <property name="visible">true</property>
+  </object>
   <template class="IdeRunButton" parent="GtkBox">
     <property name="orientation">horizontal</property>
     <style>

--- a/src/libide/workbench/ide-omni-bar.c
+++ b/src/libide/workbench/ide-omni-bar.c
@@ -589,7 +589,7 @@ ide_omni_bar__build_manager__build_finished (IdeOmniBar       *self,
   dzl_gtk_widget_remove_style_class (GTK_WIDGET (self), "building");
 }
 
-static void
+static gboolean
 ide_omni_bar__build_button__query_tooltip (IdeOmniBar *self,
                                            gint        x,
                                            gint        y,
@@ -602,6 +602,8 @@ ide_omni_bar__build_button__query_tooltip (IdeOmniBar *self,
   g_assert (GTK_IS_BUTTON (button));
 
   gtk_tooltip_set_custom (tooltip, GTK_WIDGET (self->build_button_shortcut));
+
+  return TRUE;
 }
 
 static void

--- a/src/libide/workbench/ide-omni-bar.c
+++ b/src/libide/workbench/ide-omni-bar.c
@@ -135,6 +135,7 @@ struct _IdeOmniBar
   GtkLabel             *build_result_mode_label;
   GtkButton            *build_button;
   GtkShortcutsShortcut *build_button_shortcut;
+  GtkLabel             *build_tooltip_message;
   GtkButton            *cancel_button;
   GtkLabel             *config_name_label;
   GtkLabel             *config_ready_label;
@@ -597,11 +598,35 @@ ide_omni_bar__build_button__query_tooltip (IdeOmniBar *self,
                                            GtkTooltip *tooltip,
                                            GtkButton  *button)
 {
+  IdeContext *context;
+  IdeBuildManager *build_manager;
+  gboolean enabled;
+
   g_assert (IDE_IS_OMNI_BAR (self));
   g_assert (GTK_IS_TOOLTIP (tooltip));
   g_assert (GTK_IS_BUTTON (button));
 
-  gtk_tooltip_set_custom (tooltip, GTK_WIDGET (self->build_button_shortcut));
+  if (NULL == (context = ide_widget_get_context (GTK_WIDGET (self))))
+    return FALSE;
+
+  build_manager = ide_context_get_build_manager (context);
+
+  /* Figure out if the run action is enabled. If it
+   * is not, then we should inform the user that
+   * the project cannot be run yet because the
+   * build pipeline is not yet configured. */
+  g_action_group_query_action (G_ACTION_GROUP (build_manager),
+                               "build",
+                               &enabled,
+                               NULL,
+                               NULL,
+                               NULL,
+                               NULL);
+
+  if (enabled)
+    gtk_tooltip_set_custom (tooltip, GTK_WIDGET (self->build_button_shortcut));
+  else
+    gtk_tooltip_set_custom (tooltip, GTK_WIDGET (self->build_tooltip_message));
 
   return TRUE;
 }
@@ -642,6 +667,7 @@ ide_omni_bar_class_init (IdeOmniBarClass *klass)
   gtk_widget_class_bind_template_child (widget_class, IdeOmniBar, branch_label);
   gtk_widget_class_bind_template_child (widget_class, IdeOmniBar, build_button);
   gtk_widget_class_bind_template_child (widget_class, IdeOmniBar, build_button_shortcut);
+  gtk_widget_class_bind_template_child (widget_class, IdeOmniBar, build_tooltip_message);
   gtk_widget_class_bind_template_child (widget_class, IdeOmniBar, build_result_diagnostics_image);
   gtk_widget_class_bind_template_child (widget_class, IdeOmniBar, build_result_mode_label);
   gtk_widget_class_bind_template_child (widget_class, IdeOmniBar, cancel_button);

--- a/src/libide/workbench/ide-omni-bar.ui
+++ b/src/libide/workbench/ide-omni-bar.ui
@@ -591,6 +591,10 @@
     <property name="title" translatable="yes">Build project</property>
     <property name="visible">true</property>
   </object>
+  <object class="GtkLabel" id="build_tooltip_message">
+    <property name="visible">true</property>
+    <property name="label" translatable="yes">The project cannot be built while the build pipeline is being set up</property>
+  </object>
   <object class="GtkSizeGroup">
     <property name="mode">horizontal</property>
     <widgets>


### PR DESCRIPTION
It was confusing (for me at least) to open a project in GNOME-Builder and see that I couldn't build it right away, since the animation for downloading dependencies is quite subtle.

This PR sets the tooltip contents of insensitive build and run actions to message indicating that the build pipeline is currently being set up and thus the project cannot be built or run.

It also fixes a bug which causes tooltips not to show.